### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "jQuery pull to refresh",
+    "name": "jquery-pulltorefresh",
     "version": "2.1.4",
     "homepage": "https://github.com/luis-kaufmann-silva/jquery-p2r",
     "authors": [


### PR DESCRIPTION
White spaces in name causes error, while installing from bower.json

`bower                        ENOTFOUND Package jQuery pull to refresh=pulltorefresh not found`